### PR TITLE
Fix: Objective displaying for multi-score Objectives (Custodians/Imperial)

### DIFF
--- a/src/components/Objectives/PublicObjectives/ObjectiveCard.tsx
+++ b/src/components/Objectives/PublicObjectives/ObjectiveCard.tsx
@@ -62,7 +62,7 @@ function ObjectiveCard({
 
     /* Show faction per score of objective */
   const multiScoringObjectiveBox = (
-    scoredFactions.slice(0, 6).map((faction, index) => (
+    scoredFactions.map((faction, index) => (
             <Box
               key={faction}
               className={`${styles.controlTokenSlot} ${index}`}

--- a/src/components/Objectives/PublicObjectives/ObjectiveCard.tsx
+++ b/src/components/Objectives/PublicObjectives/ObjectiveCard.tsx
@@ -15,6 +15,7 @@ type Props = {
   color: "orange" | "blue" | "gray";
   revealed?: boolean;
   scoredFactions: string[];
+  multiScoring?: boolean
   playerData: PlayerData[];
   objectiveKey: string;
 };
@@ -25,6 +26,7 @@ function ObjectiveCard({
   color,
   revealed = true,
   scoredFactions,
+  multiScoring,
   playerData,
   objectiveKey,
 }: Props) {
@@ -43,6 +45,32 @@ function ObjectiveCard({
 
   // Only show popover/clickable behavior if objective is revealed AND has data
   const shouldShowPopover = revealed && hasObjectiveData;
+
+  /* Show each faction in its designated position - faction icon if scored, empty slot if not */
+  const singleScoringObjectiveBox = (
+    allFactionsSorted.slice(0, 6).map((faction) => (
+            <Box
+              key={faction}
+              className={`${styles.controlTokenSlot} ${scoredFactionsSet.has(faction) ? "" : styles.emptySlot}`}
+            >
+              {scoredFactionsSet.has(faction) && (
+                <CircularFactionIcon faction={faction} size={28} />
+              )}
+            </Box>
+          ))
+  )
+
+    /* Show faction per score of objective */
+  const multiScoringObjectiveBox = (
+    scoredFactions.slice(0, 6).map((faction, index) => (
+            <Box
+              key={faction}
+              className={`${styles.controlTokenSlot} ${index}`}
+            >
+              <CircularFactionIcon faction={faction} size={28} />
+            </Box>
+    ))
+  )
 
   const cardContent = (
     <Shimmer
@@ -72,17 +100,7 @@ function ObjectiveCard({
 
         {/* Control token area */}
         <Box className={styles.controlTokenArea}>
-          {/* Show each faction in its designated position - faction icon if scored, empty slot if not */}
-          {allFactionsSorted.slice(0, 6).map((faction) => (
-            <Box
-              key={faction}
-              className={`${styles.controlTokenSlot} ${scoredFactionsSet.has(faction) ? "" : styles.emptySlot}`}
-            >
-              {scoredFactionsSet.has(faction) && (
-                <CircularFactionIcon faction={faction} size={28} />
-              )}
-            </Box>
-          ))}
+          {!multiScoring ? singleScoringObjectiveBox : multiScoringObjectiveBox}
         </Box>
       </Box>
     </Shimmer>

--- a/src/components/Objectives/PublicObjectives/PublicObjectives.tsx
+++ b/src/components/Objectives/PublicObjectives/PublicObjectives.tsx
@@ -9,6 +9,12 @@ type Props = {
 };
 
 function PublicObjectives({ objectives, playerData }: Props) {
+
+  objectives.customObjectives.map((objective) => (
+    console.log(objective.key),
+    console.log(objective.multiScoring)
+  ));
+  
   return (
     <Box>
       <Text className={styles.sectionTitle}>Public Objectives</Text>
@@ -69,6 +75,7 @@ function PublicObjectives({ objectives, playerData }: Props) {
                 color="gray"
                 revealed={objective.revealed}
                 scoredFactions={objective.scoredFactions}
+                multiScoring={objective.multiScoring}
                 playerData={playerData}
                 objectiveKey={objective.key}
               />

--- a/src/components/Objectives/PublicObjectives/PublicObjectives.tsx
+++ b/src/components/Objectives/PublicObjectives/PublicObjectives.tsx
@@ -9,12 +9,6 @@ type Props = {
 };
 
 function PublicObjectives({ objectives, playerData }: Props) {
-
-  objectives.customObjectives.map((objective) => (
-    console.log(objective.key),
-    console.log(objective.multiScoring)
-  ));
-  
   return (
     <Box>
       <Text className={styles.sectionTitle}>Public Objectives</Text>


### PR DESCRIPTION
Custodian/imperial objective was not displaying players who scored objective multiple times correctly. It also displayed placeholders for factions yet to score. This change defaults objectives designated as multi-scoring objectives to not hold placeholders and support displaying a faction multiple times

After change
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/e0e754a8-d0bf-4aa4-8002-9941ebff53cb" />

After change, rider example
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/871c46d6-9d82-4749-8e0a-aff604282897" />
