### PR TITLE
Fixed types.ts to conform to actual reply (v4)

### DIFF
--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -169,7 +169,7 @@ export type TileUnitData = {
   ccs: string[];
   anomaly: boolean;
   production: { [factionColor: string]: number };
-  capacity: {
+  capacity?: {
     [factionColor: string]: { total: number; used: number; ignored: number };
   };
 };
@@ -185,7 +185,7 @@ export type LawInPlay = {
   mapText: string;
   electedInfo: string | null;
   electedFaction: string | null;
-  electedType: string;
+  electedType: string | null;
   controlTokens: string[];
   displaysElectedFaction: boolean;
 };


### PR DESCRIPTION
The actual reply for game 10532 differs from the schema in types.ts in that two things are null/undefined which are not allowed to be in types.ts. This seems an error in types.ts rather than a bug in the json.