### PR TITLE
Fix: Duplicate class names of multi-scoreable CircularFactionIcons

### DIFF
--- a/src/components/Objectives/PublicObjectives/ExpandedObjectiveCard.tsx
+++ b/src/components/Objectives/PublicObjectives/ExpandedObjectiveCard.tsx
@@ -29,6 +29,7 @@ type FactionProgressData = {
 
 type CustomObjectiveDisplayProps = {
   scoredFactions: string[];
+  multiScoring: boolean;
 };
 
 type ProgressObjectiveDisplayProps = {
@@ -38,14 +39,28 @@ type ProgressObjectiveDisplayProps = {
 
 function CustomObjectiveDisplay({
   scoredFactions,
+  multiScoring,
 }: CustomObjectiveDisplayProps) {
-  return (
-    <>
-      {scoredFactions.map((faction) => (
-        <CircularFactionIcon key={faction} faction={faction} size={28} />
-      ))}
-    </>
-  );
+  if(multiScoring) {
+    let factionScoreCount = new Map<string, number>();
+    return (
+      <>
+        {scoredFactions.map((faction) => {
+          factionScoreCount.set(faction, (factionScoreCount.get(faction) ?? 0) + 1);
+        (
+          <CircularFactionIcon key={`${faction}_${factionScoreCount.get(faction)}`} faction={faction} size={28} />
+        )})}
+      </>
+    );
+  } else {
+    return (
+      <>
+        {scoredFactions.map((faction) => (
+          <CircularFactionIcon key={faction} faction={faction} size={28} />
+        ))}
+      </>
+    );
+  }
 }
 
 function ProgressObjectiveDisplay({
@@ -86,6 +101,7 @@ function ExpandedObjectiveCard({
   color,
   revealed = true,
   scoredFactions,
+  multiScoring,
   custom,
   playerData,
   objectiveKey,
@@ -113,7 +129,7 @@ function ExpandedObjectiveCard({
     if (!revealed) return null;
 
     if (custom) {
-      return <CustomObjectiveDisplay scoredFactions={scoredFactions} />;
+      return <CustomObjectiveDisplay scoredFactions={scoredFactions} multiScoring={multiScoring} />;
     }
 
     if (progressThreshold > 0) {


### PR DESCRIPTION
Fixes a small issue introduced in #44 

Scoring multiple custodians/imperial points inserted multiple class names of the same as only faction name was used as input.  Added an index into the class name based on count of objectives scored.

Before
<img width="659" alt="image" src="https://github.com/user-attachments/assets/4ebf7cc5-8990-4c68-a1ff-f52e9f4769d1" />

Post-fix no message displays