### PR TITLE
Fix: mahact edict token rendering

### DIFF
--- a/src/components/Map/MahactFleetTokenStack.tsx
+++ b/src/components/Map/MahactFleetTokenStack.tsx
@@ -25,8 +25,8 @@ export function MahactFleetTokenStack({
         {hasEdict ? "*" : ""}
       </Text>
       <Box pos="relative" style={{ height: 65 }}>
-        {/* Render blank token when regular count is 0 */}
-        {count === 0 && (
+        {/* Render blank token when total count is 0 */}
+        {totalCount === 0 && (
           <CommandCounter
             colorAlias="blank"
             style={{
@@ -60,7 +60,7 @@ export function MahactFleetTokenStack({
               colorAlias={edictColorAlias}
               style={{
                 position: "absolute",
-                left: count * 20 + 20 + index * 20,
+                left: count * 20 + (count === 0 ? 0 : 20) + index * 20,
                 zIndex: count + index + 1,
               }}
               type="fleet"

--- a/src/components/Map/PlayerStatsArea.tsx
+++ b/src/components/Map/PlayerStatsArea.tsx
@@ -229,6 +229,7 @@ export function PlayerStatsArea({
         playerData &&
         (playerData.tacticalCC > 0 ||
           playerData.fleetCC > 0 ||
+          (playerData.mahactEdict?.length && playerData.mahactEdict.length > 0) ||
           playerData.strategicCC > 0) && (
           <div
             className={styles.commandCountersOverlay}


### PR DESCRIPTION
If tactical, fleet, or strategy tokens are all less than zero, Command Counters player hex wouldn't render. I updated it to factor in the possibility of solo edict tokens.  Also removed the blank token being rendered when there are edict tokens, to be in-line with old UI.

Without regular fleet tokens (edict only)
<img width="477" height="359" alt="image" src="https://github.com/user-attachments/assets/d0fb59fe-4330-451b-8933-aaec70a7409b" />

With regular fleet tokens
<img width="419" height="264" alt="image" src="https://github.com/user-attachments/assets/273ac012-28ec-4714-907a-2b57b7b2de85" />
