### PR TITLE
Display diff of combat stats for upgradeable units

### DIFF
--- a/src/components/PlayerArea/UnitDetailsCard/UnitDetailsCard.tsx
+++ b/src/components/PlayerArea/UnitDetailsCard/UnitDetailsCard.tsx
@@ -365,7 +365,7 @@ export function UnitDetailsCard({
                 )}
               </Group>
               {upgradeInfo.upgradeUnit.ability && (
-                <Text size="sm" c="gray.6" className={styles.upgradeAbilityText}>{upgradeInfo.upgradeUnit.ability}</Text>
+                <Text size="sm" c="gray.6" mb={upgradeCombat ? 6 : 0} className={styles.upgradeAbilityText}>{upgradeInfo.upgradeUnit.ability}</Text>
               )}
 
               {/* Upgraded combat modifiers */}


### PR DESCRIPTION
### Work done

Displays the delta in combat stats on the unit details of upgradeable units.

When looking around the interface today, I didn't find a quick way to inspect my potential technology picks or unit upgrades. This was the most simple way to view that info, in my opinion, right on the unit detail popover.

Some considerations:

- This might not be the ideal place for that info.
- This introduces a minor inconsistency that units that are not unlocked (War Sun) have no preview/unit detail to show.

Also, I am a TypeScript noob. I suspect this code is not entirely up to par. I'm not using an LLM/etc. so at least my noob mistakes are natty.

### Testing

Working in tests. I noticed a small delay on click which might be normal.

I tested using my local game (first time playing today) and did not notice issues. But I'm a TI4 noob, too, so maybe there are more exotic combinations to test.

<img width="375" height="386" alt="{14B8A74F-399D-4FFA-A79C-846FEA785B28}" src="https://github.com/user-attachments/assets/6541793c-3ab8-4526-92b1-123518af2ebb" />