### PR TITLE
Fix Xxcha flex display

### DIFF
--- a/src/components/PlayerArea/ResourceInfluenceTable/EconomicsColumn.tsx
+++ b/src/components/PlayerArea/ResourceInfluenceTable/EconomicsColumn.tsx
@@ -58,9 +58,8 @@ export function EconomicsColumn({
 }: Props) {
   // When flexSpendOnly is true, show only a single flex row with the combined total
   if (flexSpendOnly) {
-    const combinedCurrent =
-      currentResources + currentInfluence + (currentFlex ?? 0);
-    const combinedTotal = totalResources + totalInfluence + (totalFlex ?? 0);
+    const combinedCurrent = currentFlex;
+    const combinedTotal = totalFlex;
 
     const currentDigits = Math.floor(combinedCurrent).toString().length;
     const totalDigits = Math.floor(combinedTotal).toString().length;

--- a/src/components/PlayerArea/ResourceInfluenceTable/EconomicsColumn.tsx
+++ b/src/components/PlayerArea/ResourceInfluenceTable/EconomicsColumn.tsx
@@ -58,18 +58,15 @@ export function EconomicsColumn({
 }: Props) {
   // When flexSpendOnly is true, show only a single flex row with the combined total
   if (flexSpendOnly) {
-    const combinedCurrent = currentFlex;
-    const combinedTotal = totalFlex;
-
-    const currentDigits = Math.floor(combinedCurrent).toString().length;
-    const totalDigits = Math.floor(combinedTotal).toString().length;
+    const currentDigits = Math.floor(currentFlex).toString().length;
+    const totalDigits = Math.floor(totalFlex).toString().length;
 
     return (
       <Stack gap={6} align="flex-start" mt={2}>
         <StatRow
           icon={<CombinedResourceInfluenceIcon size={16} />}
-          current={combinedCurrent}
-          total={combinedTotal}
+          current={currentFlex}
+          total={totalFlex}
           currentWidth={`${currentDigits}ch`}
           totalWidth={`${totalDigits}ch`}
           color="gray"


### PR DESCRIPTION
Xxcha resource/influence display is showing 3x what it should be

<img width="188" height="95" alt="Screenshot 2026-02-03 at 10 00 09 AM" src="https://github.com/user-attachments/assets/32541ada-12fa-4c44-a46b-f3c2f4110dd9" />

for flexspendonly, total/current flex is already correctly calculated before getting to the economics display. adding resources and influence again results in this 3x, lets just use the flex values