### PR TITLE
Fix: xxcha optimal spend display and remove capacity attribute from Space dock

### DIFF
--- a/src/domains/player/components/ResourceInfluenceTable/EconomicsColumn.tsx
+++ b/src/domains/player/components/ResourceInfluenceTable/EconomicsColumn.tsx
@@ -57,19 +57,15 @@ export function EconomicsColumn({
 }: Props) {
   // When flexSpendOnly is true, show only a single flex row with the combined total
   if (flexSpendOnly) {
-    const combinedCurrent =
-      currentResources + currentInfluence + (currentFlex ?? 0);
-    const combinedTotal = totalResources + totalInfluence + (totalFlex ?? 0);
-
-    const currentDigits = Math.floor(combinedCurrent).toString().length;
-    const totalDigits = Math.floor(combinedTotal).toString().length;
+    const currentDigits = Math.floor(currentFlex ?? 0).toString().length;
+    const totalDigits = Math.floor(totalFlex ?? 0).toString().length;
 
     return (
       <Stack gap={6} align="flex-start" mt={2}>
         <StatRow
           icon={<CombinedResourceInfluenceIcon size={16} />}
-          current={combinedCurrent}
-          total={combinedTotal}
+          current={currentFlex ?? 0}
+          total={totalFlex ?? 0}
           currentWidth={`${currentDigits}ch`}
           totalWidth={`${totalDigits}ch`}
           color="gray"

--- a/src/entities/data/units.ts
+++ b/src/entities/data/units.ts
@@ -511,7 +511,6 @@ export const units: Unit[] = [
     source: "absol",
     productionValue: "+4",
     basicProduction: "res",
-    capacityValue: 5,
     fleetSupplyBonus: 1,
     isStructure: true,
     ability:
@@ -1215,7 +1214,6 @@ export const units: Unit[] = [
     source: "ignis_aurora",
     productionValue: "+5",
     basicProduction: "res",
-    capacityValue: 6,
     ability:
       "This unit's PRODUCTION value is equal to 5 more than the resource value of this planet.\nUp to 6 fighters in this system do not count against your ships' capacity.",
     isStructure: true,
@@ -4960,7 +4958,6 @@ export const units: Unit[] = [
     basicProduction: "res",
     ability:
       "This unit's PRODUCTION value is equal to 2 more than the resource value of this planet.\nUp to 3 fighters in this system do not count against your ships' capacity.",
-    capacityValue: 3,
     isStructure: true,
     homebrewReplacesID: "spacedock",
   },
@@ -4974,7 +4971,6 @@ export const units: Unit[] = [
     source: "miltymod",
     productionValue: "+5",
     basicProduction: "res",
-    capacityValue: 5,
     isStructure: true,
     ability:
       "This unit's PRODUCTION value is equal to 5 more than the resource value of this planet.\nUp to 5 fighters in this system do not count against your ships' capacity.\nWhen you use this unit's PRODUCTION ability, you may place the produced units on any planet in this system.",
@@ -9401,7 +9397,6 @@ export const units: Unit[] = [
     source: "base",
     productionValue: "+2",
     basicProduction: "res",
-    capacityValue: 3,
     isStructure: true,
     imageURL: "/hover_images/units/generic/spacedock.png",
     ability:
@@ -9418,7 +9413,6 @@ export const units: Unit[] = [
     source: "base",
     productionValue: "+4",
     basicProduction: "res",
-    capacityValue: 3,
     isStructure: true,
     imageURL: "/hover_images/techs/generic/spacedock_2.jpg",
     ability:


### PR DESCRIPTION
Fix a couple issues

xxcha
<img width="272" height="324" alt="image" src="https://github.com/user-attachments/assets/487d3f58-b47e-41bd-8af1-135ecf2c79e9" />

Normal space dock
<img width="266" height="301" alt="image" src="https://github.com/user-attachments/assets/cfa6e101-0a71-4b6e-b165-b863ae71c44b" />


Saar still fine
<img width="256" height="265" alt="image" src="https://github.com/user-attachments/assets/26cf2fd7-cb3d-480f-9f93-b55cb66139a6" />
