### PR TITLE
Adding support for emoji faction icons

### DIFF
--- a/src/entities/lookup/factions.ts
+++ b/src/entities/lookup/factions.ts
@@ -7,6 +7,7 @@ export function getFactionImage(
   factionImage?: string,
   factionImageType?: string
 ): string | undefined {
+  if (factionImageType === "EMOJI") return `https://emoji-cdn.mqrio.dev/${factionImage}?style=twitter`
   if (factionImageType === "DISCORD") return factionImage;
   return cdnImage(`/factions/${faction}.png`);
 }


### PR DESCRIPTION
This is using the open source emoji CDN detailed here: [GitHub Repo](https://github.com/oddmario/emoji-cdn)

This is by far the simplest solution. The main potential issue to consider with this approach is that it is relying on an externally maintained host, which could shut down at any time. I do not believe this is a major issue as most emoji based faction icons are broken images in current state, so we would just return to that. And I'm really not sure how many users make use of the ./franken_set_faction_icon feature of the bot so it would be a small impact if it did shut down.
