### PR TITLE
Let Firefox use the zoom CSS property

### DIFF
--- a/src/domains/map/components/mapLayout.ts
+++ b/src/domains/map/components/mapLayout.ts
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { getCssScaleStyle, getScaleStyle } from "@/utils/zoom";
+import { getScaleStyle } from "@/utils/zoom";
 
 export type MapLayout = "panels" | "pannable";
 
@@ -45,7 +45,9 @@ export function getMapScaleStyle(
   isFirefox: boolean
 ): CSSProperties {
   return config.useCssZoom
-    ? getCssScaleStyle(zoom, isFirefox)
+    ? {
+        zoom: zoom,
+      }
     : getScaleStyle(zoom, isFirefox);
 }
 

--- a/src/image-map/components/ScrollMap.tsx
+++ b/src/image-map/components/ScrollMap.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useState, useEffect, type CSSProperties } from "react";
 import ZoomControls from "@/shared/ui/map/ZoomControls";
-import { useAppStore, useSettingsStore } from "@/utils/appStore";
-import { getCssScaleStyle } from "@/utils/zoom";
+import { useAppStore } from "@/utils/appStore";
 import { isMobileDevice } from "@/utils/isTouchDevice";
 import { useOverlayData, type OverlayData } from "../hooks/useOverlayData";
 import { abilities } from "@/entities/data/abilities";
@@ -54,9 +53,10 @@ export function ScrollMap({ gameId, imageUrl }: ScrollMapProps) {
 
   const zoom = useAppStore((s) => s.zoomLevel);
   const zoomFitToScreen = useAppStore((s) => s.zoomFitToScreen);
-  const isFirefox = useSettingsStore((s) => s.settings.isFirefox);
   const imageScale = zoomFitToScreen ? 1 : zoom;
-  const imageScaleStyle = getCssScaleStyle(imageScale, isFirefox);
+  const imageScaleStyle = {
+    zoom: imageScale,
+  };
 
   const [containerWidth, setContainerWidth] = useState(() => window.innerWidth);
   useEffect(() => {

--- a/src/utils/zoom.ts
+++ b/src/utils/zoom.ts
@@ -114,18 +114,6 @@ export function getScaleStyle(
   } as const;
 }
 
-export function getCssScaleStyle(scale: number, isFirefox: boolean) {
-  if (isFirefox) {
-    return {
-      MozTransform: `scale(${scale})`,
-      MozTransformOrigin: "top left",
-    };
-  }
-  return {
-    zoom: scale,
-  };
-}
-
 export function getScaledDimensions(
   width: number,
   height: number,


### PR DESCRIPTION
I noticed that tool-tips on planets and units were strange and offset on Firefox compared to Chrome and found that it was because of the zoom level on the Map.

Firefox is capable of using the `zoom` CSS variable and displays the map the same as Chrome with it.