### PR TITLE
Fix: Add additional glory token entity data

### DIFF
--- a/src/entities/data/tokens.ts
+++ b/src/entities/data/tokens.ts
@@ -264,6 +264,18 @@ export const tokens: Token[] = [
     source: "ds",
   },
   {
+    id: "glory2",
+    imagePath: "token_ds_glory2.png",
+    spaceOrPlanet: "space",
+    source: "ds",
+  },
+  {
+    id: "glory3",
+    imagePath: "token_ds_glory3.png",
+    spaceOrPlanet: "space",
+    source: "ds",
+  },
+  {
     id: "gravityrift",
     imagePath: "token_gravityrift.png",
     spaceOrPlanet: "space",


### PR DESCRIPTION
Glory tokens have separate entity ids

<img width="848" height="1016" alt="image" src="https://github.com/user-attachments/assets/3301d60f-afbe-41d1-af29-bd2faf87c614" />
