### PR TITLE
refactor: Improve mobile visibility control for header components

### DIFF
--- a/src/NewMapUI.tsx
+++ b/src/NewMapUI.tsx
@@ -82,6 +82,7 @@ function NewMapUIContent({ pannable, onShowOldUI }: Props) {
         gameId={gameId}
         buttonLabel="OLD UI"
         onButtonClick={onShowOldUI}
+        hideOnMobile={true}
       />
 
       <AppShell.Main>

--- a/src/image-map/components/MapUI.tsx
+++ b/src/image-map/components/MapUI.tsx
@@ -1,4 +1,4 @@
-import { AppShell, Box } from "@mantine/core";
+import {AppShell, Flex} from "@mantine/core";
 import MapImageErrorDialog from "@/image-map/components/MapImageErrorDialog";
 import { ScrollMap } from "./ScrollMap";
 import { DiscordLogin } from "@/domains/auth/DiscordLogin";
@@ -10,6 +10,8 @@ import type { Params } from "react-router-dom";
 import { APP_HEADER_HEIGHT } from "@/shared/ui/AppHeader";
 
 import "../styles/MapScreen.css";
+import {DashboardLinks} from "@/shared/ui/DashboardLinks.tsx";
+import {useUser} from "@/hooks/useUser.ts";
 
 type MapUIProps = {
   params: Params<"mapid">;
@@ -33,6 +35,7 @@ function MapUI({
   onShowNewUI,
 }: MapUIProps) {
   const gameId = params.mapid ?? "";
+  const { user } = useUser();
 
   return (
     <AppShell header={{ height: APP_HEADER_HEIGHT }}>
@@ -45,9 +48,10 @@ function MapUI({
       <AppShell.Main>
         <div className="main">
           <div className="imageContainer">
-            <Box p="xs" hiddenFrom="sm">
+            <Flex p="xs" hiddenFrom="sm" justify="space-between">
+              {user?.authenticated && ( <DashboardLinks /> )}
               <DiscordLogin />
-            </Box>
+            </Flex>
 
             {isError ? (
               <MapImageErrorDialog gameId={gameId} error={error} />

--- a/src/shared/ui/DashboardLinks.tsx
+++ b/src/shared/ui/DashboardLinks.tsx
@@ -5,11 +5,17 @@ import { Group } from "@mantine/core";
 import cx from "clsx";
 import classes from "@/domains/game-shell/components/chrome/HeaderMenuNew.module.css";
 
-export function DashboardLinks() {
+export type DashboardLinksProps = {
+    hideOnMobile?: boolean;
+};
+
+export function DashboardLinks({
+    hideOnMobile
+}: DashboardLinksProps) {
   const { pathname } = useLocation();
 
   return (
-    <Group gap={6} wrap="nowrap" visibleFrom="sm">
+    <Group gap={6} wrap="nowrap" visibleFrom={hideOnMobile ? "sm" : undefined}>
       <NavLink
         to="/dashboard"
         active={pathname === "/dashboard"}

--- a/src/shared/ui/GamesBar.tsx
+++ b/src/shared/ui/GamesBar.tsx
@@ -18,7 +18,7 @@ export function GamesBar({ currentMapId }: GamesBarProps) {
       activeTabs={activeTabs}
       changeTab={changeTab}
       removeTab={removeTab}
-      actions={user?.authenticated ? <DashboardLinks /> : undefined}
+      actions={user?.authenticated ? <DashboardLinks hideOnMobile={true} /> : undefined}
     />
   );
 }

--- a/src/shared/ui/MapHeaderSwitch.tsx
+++ b/src/shared/ui/MapHeaderSwitch.tsx
@@ -5,6 +5,7 @@ export type MapHeaderSwitchProps = {
   gameId: string;
   buttonLabel: string;
   onButtonClick?: () => void;
+  hideOnMobile?: boolean;
 };
 
 /**
@@ -15,10 +16,11 @@ export function MapHeaderSwitch({
   gameId,
   buttonLabel,
   onButtonClick,
+  hideOnMobile,
 }: MapHeaderSwitchProps) {
   return (
     <SiteHeader currentMapId={gameId}>
-      <Button variant="light" size="xs" color="cyan" onClick={onButtonClick} visibleFrom="sm">
+      <Button variant="light" size="xs" color="cyan" onClick={onButtonClick} visibleFrom={hideOnMobile ? "sm" : undefined}>
         {buttonLabel}
       </Button>
     </SiteHeader>


### PR DESCRIPTION
Generalizes the `hideOnMobile` prop for `DashboardLinks` and `MapHeaderSwitch`, allowing components to conditionally render on small screens. This change:

- Hides the "OLD UI" switch button and dashboard navigation links in the `GamesBar` header on mobile devices.
- Adds dashboard navigation links to the mobile view of the old map UI for better accessibility on smaller screens.
