### PR TITLE
Feature: SC enhancements & neutral combat stats

### DIFF
--- a/src/domains/game-shell/components/MapUnitDetailsCard.tsx
+++ b/src/domains/game-shell/components/MapUnitDetailsCard.tsx
@@ -29,13 +29,18 @@ export function MapUnitDetailsCard({
   const gameData = useGameData();
   const playerData = gameData?.playerData;
 
+  // Try to find a player matching the faction; neutral units may not have an associated player
   const activePlayer = playerData?.find(
     (player) => player.faction === tooltipUnit.faction
   );
-  if (!activePlayer) return null;
 
+  // If we don't have a player for this faction (e.g. neutral), still attempt to resolve
+  // a sensible unit id for display. Pass `activePlayer?.faction` when available so
+  // faction-specific lookups prefer that, otherwise fall back to the tooltip faction
+  // which allows `lookupUnit` to return generic unit data.
+  const lookupFaction = activePlayer?.faction || tooltipUnit.faction;
   const unitIdToUse =
-    lookupUnit(tooltipUnit.unitId, activePlayer.faction, activePlayer)?.id ||
+    lookupUnit(tooltipUnit.unitId, lookupFaction, activePlayer)?.id ||
     tooltipUnit.unitId;
 
   return (
@@ -46,7 +51,7 @@ export function MapUnitDetailsCard({
       mapLayout={mapLayout}
       zIndexVar="var(--z-map-unit-details)"
     >
-      <UnitDetailsCard unitId={unitIdToUse} color={activePlayer.color} />
+      <UnitDetailsCard unitId={unitIdToUse} color={activePlayer?.color} />
     </MapTooltipPositioner>
   );
 }

--- a/src/domains/game-shell/components/MapUnitDetailsCard.tsx
+++ b/src/domains/game-shell/components/MapUnitDetailsCard.tsx
@@ -29,15 +29,10 @@ export function MapUnitDetailsCard({
   const gameData = useGameData();
   const playerData = gameData?.playerData;
 
-  // Try to find a player matching the faction; neutral units may not have an associated player
   const activePlayer = playerData?.find(
     (player) => player.faction === tooltipUnit.faction
   );
 
-  // If we don't have a player for this faction (e.g. neutral), still attempt to resolve
-  // a sensible unit id for display. Pass `activePlayer?.faction` when available so
-  // faction-specific lookups prefer that, otherwise fall back to the tooltip faction
-  // which allows `lookupUnit` to return generic unit data.
   const lookupFaction = activePlayer?.faction || tooltipUnit.faction;
   const unitIdToUse =
     lookupUnit(tooltipUnit.unitId, lookupFaction, activePlayer)?.id ||

--- a/src/domains/game-shell/components/UnpickedSCs/UnpickedSCs.tsx
+++ b/src/domains/game-shell/components/UnpickedSCs/UnpickedSCs.tsx
@@ -21,6 +21,7 @@ function UnpickedSCs({ strategyCards }: Props) {
             <StrategyCard
               key={index}
               initiative={card.initiative}
+              tradeGoods={card.tradeGoods}
             />
           ))}
         </SimpleGrid>

--- a/src/domains/player/components/StrategyCard.module.css
+++ b/src/domains/player/components/StrategyCard.module.css
@@ -99,3 +99,17 @@
   text-transform: uppercase;
   white-space: nowrap;
 }
+
+.tradeGoodsContainer {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden; 
+  height: 24px;
+
+}
+
+.tradeGoodsImage {
+  height: 24px;
+  margin-top: 8px;
+}

--- a/src/domains/player/components/StrategyCard.tsx
+++ b/src/domains/player/components/StrategyCard.tsx
@@ -13,6 +13,7 @@ import { useGameData } from "@/hooks/useGameContext";
 import { StrategyCardDetailsCard } from "./StrategyCardDetailsCard";
 import type { ColorKey } from "./gradientClasses";
 import classes from "./StrategyCard.module.css";
+import { cdnImage } from "@/entities/data/cdnImage";
 
 type StrategyCardColor = Extract<
   ColorKey,
@@ -21,6 +22,7 @@ type StrategyCardColor = Extract<
 
 type Props = {
   initiative: number;
+  tradeGoods: number;
   isExhausted?: boolean;
 };
 
@@ -42,7 +44,7 @@ function getStrategyCardColor(initiative: number): StrategyCardColor {
     : "red";
 }
 
-export function StrategyCard({ initiative, isExhausted = false }: Props) {
+export function StrategyCard({ initiative, tradeGoods, isExhausted = false}: Props) {
   const { opened, setOpened, toggle } = useDisclosure(false);
   const gameData = useGameData();
   const strategyCard = getStrategyCardByInitiative(
@@ -73,14 +75,26 @@ export function StrategyCard({ initiative, isExhausted = false }: Props) {
                 />
               </span>
             )}
+              {/* Trade Goods */}
           </Box>
           <Text ff="heading" className={classes.name}>
             {strategyCard?.name || SC_NAMES[initiative]}
           </Text>
+            {tradeGoods > 0 && (
+              <span className={classes.tradeGoodsContainer}>
+                <img
+                src={cdnImage("/player_area/pa_cardbacks_tradegoods.png")}
+                className={classes.tradeGoodsImage}
+              />
+              <Text size="16px" fw={600} c="white" ff="heading">
+                  {tradeGoods}
+                </Text>
+              </span>
+            )}
         </Chip>
       </SmoothPopover.Target>
       <SmoothPopover.Dropdown p={0}>
-        <StrategyCardDetailsCard initiative={initiative} color={color} />
+        <StrategyCardDetailsCard initiative={initiative} color={color} tradeGoods={tradeGoods} />
       </SmoothPopover.Dropdown>
     </SmoothPopover>
   );

--- a/src/domains/player/components/StrategyCardDetailsCard.tsx
+++ b/src/domains/player/components/StrategyCardDetailsCard.tsx
@@ -24,6 +24,7 @@ type Props = {
     | "cyan"
     | "blue"
     | "purple";
+  tradeGoods?: number;
 };
 
 function mapDetailsCardColor(color?: Props["color"]): DetailsColor {
@@ -38,7 +39,7 @@ function mapDetailsCardColor(color?: Props["color"]): DetailsColor {
   return "none";
 }
 
-export function StrategyCardDetailsCard({ initiative, color }: Props) {
+export function StrategyCardDetailsCard({ initiative, color, tradeGoods }: Props) {
   const gameData = useGameData();
   const sc = getStrategyCardByInitiative(
     initiative,

--- a/src/domains/player/components/StrategyCardDetailsCard.tsx
+++ b/src/domains/player/components/StrategyCardDetailsCard.tsx
@@ -24,7 +24,6 @@ type Props = {
     | "cyan"
     | "blue"
     | "purple";
-  tradeGoods?: number;
 };
 
 function mapDetailsCardColor(color?: Props["color"]): DetailsColor {
@@ -39,7 +38,7 @@ function mapDetailsCardColor(color?: Props["color"]): DetailsColor {
   return "none";
 }
 
-export function StrategyCardDetailsCard({ initiative, color, tradeGoods }: Props) {
+export function StrategyCardDetailsCard({ initiative, color }: Props) {
   const gameData = useGameData();
   const sc = getStrategyCardByInitiative(
     initiative,

--- a/src/shared/ui/primitives/Chip.module.css
+++ b/src/shared/ui/primitives/Chip.module.css
@@ -19,6 +19,7 @@
 .cyan { --accent-rgb: var(--gd-cyan); }
 .red { --accent-rgb: var(--gd-red); }
 .blue { --accent-rgb: var(--gd-blue); }
+.teal { --accent-rgb: var(--gd-teal); }
 .green { --accent-rgb: var(--gd-green); }
 .purple { --accent-rgb: var(--gd-purple); }
 


### PR DESCRIPTION
- Fixed Trade Strategy Card color
- Added TG display to unpicked SCs
- Added neutral unit hover functionality for combat stats

<img width="154" height="173" alt="image" src="https://github.com/user-attachments/assets/17dc6362-043c-49e8-93bc-c5b133d95aac" />

<img width="470" height="269" alt="image" src="https://github.com/user-attachments/assets/42811712-055f-43dd-8eb9-3bb6736724f3" />

<img width="490" height="416" alt="image" src="https://github.com/user-attachments/assets/ae7ac8de-738c-426f-afaf-107a13dd07f2" />
