### PR TITLE
feat: Introduce flexible player faction display names

### DIFF
--- a/src/domains/map/components/PlayerStatsArea.tsx
+++ b/src/domains/map/components/PlayerStatsArea.tsx
@@ -18,6 +18,7 @@ import { useGameContext } from "@/hooks/useGameContext";
 import { useFactionImages } from "@/hooks/useFactionImages";
 import { getFactionImage } from "@/entities/lookup/factions";
 import cx from "clsx";
+import { getPlayerFactionDisplayName } from "@/utils/playerUtils";
 
 type PlayerStatsAreaProps = {
   faction: string;
@@ -139,7 +140,9 @@ export function PlayerStatsArea({
             }}
           />
           <div className={styles.textContainer}>
-            <div className={styles.factionName}>{faction.toUpperCase()}</div>
+            <div className={styles.factionName}>
+              {getPlayerFactionDisplayName(playerData).toUpperCase()}
+            </div>
 
             {playerData.userName && (
               <div className={styles.playerName}>{playerData.userName}</div>

--- a/src/domains/objectives/components/PublicObjectives/ObjectiveDetailsCard.tsx
+++ b/src/domains/objectives/components/PublicObjectives/ObjectiveDetailsCard.tsx
@@ -5,6 +5,7 @@ import { PlayerData } from "@/entities/data/types";
 import { CircularFactionIcon } from "@/shared/ui/CircularFactionIcon";
 import { DetailsCard } from "@/shared/ui/DetailsCard";
 import classes from "./ObjectiveDetailsCard.module.css";
+import { getPlayerFactionDisplayName } from "@/utils/playerUtils";
 
 type Props = {
   objectiveKey: string;
@@ -113,7 +114,7 @@ export function ObjectiveDetailsCard({
                         tt="uppercase"
                         className={classes.factionName}
                       >
-                        {player.faction}
+                        {getPlayerFactionDisplayName(player)}
                       </Text>
                       <Text size="sm" c="gray.3" className={classes.playerName}>
                         {player.userName.length > 12

--- a/src/domains/player/components/PlayerCardHeader/PlayerCardHeaderCompact.tsx
+++ b/src/domains/player/components/PlayerCardHeader/PlayerCardHeaderCompact.tsx
@@ -14,6 +14,7 @@ import { lowPriorityImageProps } from "@/shared/ui/imageLoading";
 type PlayerCardHeaderProps = {
   userName: string;
   faction: string;
+  factionDisplayName: string;
   color: string;
   factionImageUrl: string;
   isSpeaker?: boolean;
@@ -52,6 +53,7 @@ const MOBILE_BREAKTHROUGH_WIDTH = 176;
 export function PlayerCardHeaderCompact({
   userName,
   faction,
+  factionDisplayName,
   color,
   factionImageUrl,
   isSpeaker = false,
@@ -116,7 +118,7 @@ export function PlayerCardHeaderCompact({
             minWidth: 0,
           }}
         >
-          [{faction}]
+          [{factionDisplayName}]
         </Text>
         <Box style={{ flexShrink: 2 }}>
           <PlayerColor color={color} size="sm" />
@@ -136,6 +138,7 @@ export function PlayerCardHeaderCompact({
 export function PlayerCardHeaderFull({
   userName,
   faction,
+  factionDisplayName,
   color,
   factionImageUrl,
   isSpeaker = false,
@@ -184,7 +187,7 @@ export function PlayerCardHeaderFull({
               ff="text"
               style={{ textShadow: "0 1px 1px rgba(0, 0, 0, 0.62)" }}
             >
-              {faction}
+              {factionDisplayName}
             </Text>
             <PlayerColor color={color} size="xs" />
           </Group>
@@ -206,6 +209,7 @@ export function PlayerCardHeaderFull({
 export function PlayerCardHeaderMobile({
   userName,
   faction,
+  factionDisplayName,
   color,
   factionImageUrl,
   isSpeaker = false,
@@ -281,7 +285,7 @@ export function PlayerCardHeaderMobile({
             flex: "0 0 auto",
           }}
         >
-          [{faction}]
+          [{factionDisplayName}]
         </Text>
         <PlayerColor color={color} size="xs" />
         <StatusIndicator passed={passed} active={active} />

--- a/src/domains/player/components/PlayerCardShared/getPlayerCardLayoutFields.ts
+++ b/src/domains/player/components/PlayerCardShared/getPlayerCardLayoutFields.ts
@@ -1,4 +1,5 @@
 import type { PlayerData } from "@/entities/data/types";
+import { getPlayerFactionDisplayName } from "@/utils/playerUtils";
 
 /**
  * Picks the common set of player fields that multiple PlayerCard variants need
@@ -50,6 +51,7 @@ export function getPlayerCardLayoutFields(playerData: PlayerData) {
   return {
     userName,
     faction,
+    factionDisplayName: getPlayerFactionDisplayName(playerData),
     color,
     tacticalCC,
     fleetCC,

--- a/src/domains/player/components/composition/PlayerCard.tsx
+++ b/src/domains/player/components/composition/PlayerCard.tsx
@@ -61,6 +61,7 @@ export default function PlayerCard(props: Props) {
       <PlayerCardHeaderFull
         userName={player.userName}
         faction={player.faction}
+        factionDisplayName={player.factionDisplayName}
         color={player.color}
         factionImageUrl={factionUrl ?? ""}
         isSpeaker={player.isSpeaker}

--- a/src/domains/player/components/composition/PlayerCardMobile.tsx
+++ b/src/domains/player/components/composition/PlayerCardMobile.tsx
@@ -270,6 +270,7 @@ export default function PlayerCardMobile(props: Props) {
       <PlayerCardHeaderMobile
         userName={player.userName}
         faction={player.faction}
+        factionDisplayName={player.factionDisplayName}
         color={player.color}
         factionImageUrl={factionUrl ?? ""}
         isSpeaker={player.isSpeaker}

--- a/src/domains/player/components/composition/PlayerCardSidebar.tsx
+++ b/src/domains/player/components/composition/PlayerCardSidebar.tsx
@@ -16,6 +16,7 @@ import { PlayerCardPlanetsSection } from "@/domains/player/components/PlayerCard
 import { PlayerCardPlanetsArea } from "@/domains/player/components/PlayerCardPlanetsArea";
 import { ReinforcementTokensGroup } from "@/domains/player/components/ReinforcementTokensGroup";
 import { Nombox } from "./Nombox";
+import { getPlayerFactionDisplayName } from "@/utils/playerUtils";
 
 type Props = {
   playerData: PlayerData;
@@ -67,6 +68,7 @@ export default function PlayerCardSidebar(props: Props) {
       <PlayerCardHeaderCompact
         userName={userName}
         faction={faction}
+        factionDisplayName={getPlayerFactionDisplayName(playerData)}
         color={color}
         factionImageUrl={factionUrl}
         isSpeaker={isSpeaker}

--- a/src/utils/playerUtils.ts
+++ b/src/utils/playerUtils.ts
@@ -2,6 +2,20 @@ import { PlayerData } from "@/entities/data/types";
 
 const INVALID_FACTION_VALUES = new Set(["", "null", "neutral"]);
 
+function cleanDisplayName(value?: string | null) {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.toLowerCase() === "null") return null;
+  return trimmed;
+}
+
+export function getPlayerFactionDisplayName(player: PlayerData) {
+  return (
+    cleanDisplayName(player.displayName) ??
+    cleanDisplayName(player.flexibleDisplayName) ??
+    player.faction
+  );
+}
+
 export function hasAssignedFaction(
   player?: PlayerData | null,
 ): player is PlayerData {


### PR DESCRIPTION
Prioritizes custom 'displayName' or 'flexibleDisplayName' over raw faction IDs for improved user experience and consistency across UI components. This centralizes the logic for determining which faction name to display.