### PR TITLE
Faction images: client-side cache, visual consistency for tabs, automatic pruning

### DIFF
--- a/src/app/providers/context/GameContextProvider.tsx
+++ b/src/app/providers/context/GameContextProvider.tsx
@@ -24,6 +24,7 @@ import {
   type MapReplayPlan,
 } from "@/utils/historicalMapTransitions";
 import { isMobileDevice } from "@/utils/isTouchDevice";
+import { storeFactionImagesForGame } from "@/utils/factionImageCache";
 
 const MAX_CACHED_MAP_PREVIEWS = 16;
 const EMPTY_MAP_REPLAY_PLAN: MapReplayPlan = {
@@ -211,6 +212,11 @@ export function GameContextProvider({ children, gameId }: Props) {
     if (!displacedData) return undefined;
     return buildGameContext(displacedData, accessibleColors, decalOverrides);
   }, [displacedData, accessibleColors, decalOverrides]);
+
+  useEffect(() => {
+    if (!liveEnhancedData) return;
+    storeFactionImagesForGame(gameId, liveEnhancedData.factionImageMap);
+  }, [gameId, liveEnhancedData]);
 
   // Preview states are immutable and identified by their deterministic compact
   // string. Reusing their built contexts avoids repeating tile enrichment and

--- a/src/hooks/useFactionImageCache.ts
+++ b/src/hooks/useFactionImageCache.ts
@@ -1,0 +1,14 @@
+import { useSyncExternalStore } from "react";
+import {
+  getEmptyFactionImageCacheSnapshot,
+  getFactionImageCacheSnapshot,
+  subscribeToFactionImageCache,
+} from "@/utils/factionImageCache";
+
+export function useFactionImageCache() {
+  return useSyncExternalStore(
+    subscribeToFactionImageCache,
+    getFactionImageCacheSnapshot,
+    getEmptyFactionImageCacheSnapshot,
+  );
+}

--- a/src/hooks/usePersistentGameTabs.ts
+++ b/src/hooks/usePersistentGameTabs.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { pruneFactionImageCache } from "@/utils/factionImageCache";
 
 const STORAGE_KEY = "activeTabs";
 
@@ -14,7 +15,7 @@ function readStoredTabs(): string[] {
       return [];
     }
 
-    const parsed = JSON.parse(raw);
+    const parsed = JSON.parse(raw) as unknown;
 
     return Array.isArray(parsed)
       ? parsed.filter((tab): tab is string => isNonEmptyString(tab))
@@ -27,6 +28,7 @@ function readStoredTabs(): string[] {
 
 function persistTabs(tabs: string[]) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(tabs));
+  pruneFactionImageCache(tabs);
 }
 
 export function usePersistentGameTabs() {
@@ -41,6 +43,7 @@ export function usePersistentGameTabs() {
       new Set([...storedTabs, currentGame].filter(isNonEmptyString)),
     );
     setActiveTabs(normalizedTabs);
+    pruneFactionImageCache(normalizedTabs);
   }, [params.mapid]);
 
   useEffect(() => {

--- a/src/hooks/useTabManagementV2.ts
+++ b/src/hooks/useTabManagementV2.ts
@@ -1,8 +1,11 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
 import { authenticatedFetch, getBotApiUrl } from "@/domains/auth/api";
 import { usePersistentGameTabs } from "./usePersistentGameTabs";
 import { EnrichedTab } from "@/app/providers/context/types";
+import { useFactionImageCache } from "./useFactionImageCache";
+import { useGameData } from "./useGameContext";
 
 type PlayerGame = {
   gameId: string;
@@ -43,6 +46,9 @@ function usePlayerGames() {
 export function useTabManagementV2() {
   const { activeTabs, changeTab, removeTab } = usePersistentGameTabs();
   const { data: playerGamesData } = usePlayerGames();
+  const currentGameId = useParams<{ mapid?: string }>().mapid;
+  const liveFactionImages = useGameData()?.factionImageMap;
+  const factionImageCache = useFactionImageCache();
 
   const enrichedTabs: EnrichedTab[] = useMemo(() => {
     const playerGames = playerGamesData ?? [];
@@ -55,19 +61,35 @@ export function useTabManagementV2() {
       .map((tabId) => {
         const gameData = playerGames.find((game) => game.gameId === tabId);
         const isManaged = !!gameData;
+        const faction =
+          gameData?.faction === "null" ? null : gameData?.faction || null;
+        const imageData = faction
+          ? (tabId === currentGameId
+              ? liveFactionImages?.[faction]
+              : undefined) ??
+            factionImageCache.games[tabId]?.factionImages[faction]
+          : undefined;
+
         return {
           id: tabId,
-          faction:
-            gameData?.faction === "null" ? null : gameData?.faction || null,
+          faction,
           factionColor:
             gameData?.color === "null" ? null : gameData?.color || null,
-          factionImage: null,
-          factionImageType: null,
+          // Empty strings are an explicit default-image override. Nullish values
+          // would fall through to the currently viewed game's faction map.
+          factionImage: imageData?.image ?? "",
+          factionImageType: imageData?.type ?? "",
           isManaged,
         };
       })
       .sort((a, b) => a.id.localeCompare(b.id));
-  }, [activeTabs, playerGamesData]);
+  }, [
+    activeTabs,
+    currentGameId,
+    factionImageCache,
+    liveFactionImages,
+    playerGamesData,
+  ]);
 
   return { activeTabs: enrichedTabs, changeTab, removeTab };
 }

--- a/src/utils/factionImageCache.ts
+++ b/src/utils/factionImageCache.ts
@@ -1,0 +1,212 @@
+import type { FactionImageMap } from "@/app/providers/context/types";
+
+const STORAGE_KEY = "factionImageCache";
+const CACHE_VERSION = 1;
+const MAX_CACHE_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type CachedGameFactionImages = {
+  factionImages: FactionImageMap;
+  updatedAt: number;
+};
+
+export type FactionImageCache = {
+  version: typeof CACHE_VERSION;
+  games: Record<string, CachedGameFactionImages>;
+};
+
+const EMPTY_CACHE: FactionImageCache = {
+  version: CACHE_VERSION,
+  games: {},
+};
+
+const listeners = new Set<() => void>();
+let cacheSnapshot: FactionImageCache | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseFactionImages(value: unknown): FactionImageMap {
+  if (!isRecord(value)) return {};
+
+  return Object.entries(value).reduce<FactionImageMap>(
+    (factionImages, [faction, imageData]) => {
+      if (
+        faction.length > 0 &&
+        isRecord(imageData) &&
+        typeof imageData.image === "string" &&
+        typeof imageData.type === "string"
+      ) {
+        factionImages[faction] = {
+          image: imageData.image,
+          type: imageData.type,
+        };
+      }
+
+      return factionImages;
+    },
+    {},
+  );
+}
+
+function parseCache(value: unknown): FactionImageCache {
+  if (
+    !isRecord(value) ||
+    value.version !== CACHE_VERSION ||
+    !isRecord(value.games)
+  ) {
+    return EMPTY_CACHE;
+  }
+
+  const games = Object.entries(value.games).reduce<
+    FactionImageCache["games"]
+  >((cachedGames, [gameId, gameData]) => {
+    if (
+      gameId.length === 0 ||
+      !isRecord(gameData) ||
+      !Number.isFinite(gameData.updatedAt)
+    ) {
+      return cachedGames;
+    }
+
+    cachedGames[gameId] = {
+      factionImages: parseFactionImages(gameData.factionImages),
+      updatedAt: gameData.updatedAt as number,
+    };
+    return cachedGames;
+  }, {});
+
+  return { version: CACHE_VERSION, games };
+}
+
+function readCache(): FactionImageCache {
+  if (typeof window === "undefined") return EMPTY_CACHE;
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored ? parseCache(JSON.parse(stored) as unknown) : EMPTY_CACHE;
+  } catch (error) {
+    console.warn("Failed to load cached faction images", error);
+    return EMPTY_CACHE;
+  }
+}
+
+function factionImageMapsEqual(
+  first: FactionImageMap,
+  second: FactionImageMap,
+) {
+  const firstFactions = Object.keys(first);
+  const secondFactions = Object.keys(second);
+
+  return (
+    firstFactions.length === secondFactions.length &&
+    firstFactions.every(
+      (faction) =>
+        first[faction]?.image === second[faction]?.image &&
+        first[faction]?.type === second[faction]?.type,
+    )
+  );
+}
+
+function emitCacheChange() {
+  listeners.forEach((listener) => listener());
+}
+
+function persistCache(nextCache: FactionImageCache) {
+  cacheSnapshot = nextCache;
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextCache));
+  } catch (error) {
+    console.warn("Failed to cache faction images", error);
+  }
+
+  emitCacheChange();
+}
+
+function handleStorageChange(event: StorageEvent) {
+  if (event.key !== null && event.key !== STORAGE_KEY) return;
+  cacheSnapshot = readCache();
+  emitCacheChange();
+}
+
+export function getFactionImageCacheSnapshot(): FactionImageCache {
+  cacheSnapshot ??= readCache();
+  return cacheSnapshot;
+}
+
+export function getEmptyFactionImageCacheSnapshot(): FactionImageCache {
+  return EMPTY_CACHE;
+}
+
+export function subscribeToFactionImageCache(listener: () => void) {
+  listeners.add(listener);
+
+  if (listeners.size === 1 && typeof window !== "undefined") {
+    window.addEventListener("storage", handleStorageChange);
+  }
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && typeof window !== "undefined") {
+      window.removeEventListener("storage", handleStorageChange);
+    }
+  };
+}
+
+/** Retains only recent cache entries that still have a persisted game tab. */
+export function pruneFactionImageCache(
+  persistedGameIds: readonly string[],
+  now = Date.now(),
+) {
+  const currentCache = getFactionImageCacheSnapshot();
+  const persistedGames = new Set(persistedGameIds);
+  const oldestAllowedUpdate = now - MAX_CACHE_AGE_MS;
+  const retainedGames = Object.fromEntries(
+    Object.entries(currentCache.games).filter(
+      ([gameId, gameData]) =>
+        persistedGames.has(gameId) &&
+        gameData.updatedAt >= oldestAllowedUpdate,
+    ),
+  );
+
+  if (
+    Object.keys(retainedGames).length === Object.keys(currentCache.games).length
+  ) {
+    return;
+  }
+
+  persistCache({
+    version: CACHE_VERSION,
+    games: retainedGames,
+  });
+}
+
+export function storeFactionImagesForGame(
+  gameId: string,
+  factionImages: FactionImageMap,
+) {
+  if (!gameId) return;
+
+  const normalizedFactionImages = parseFactionImages(factionImages);
+  const currentCache = getFactionImageCacheSnapshot();
+  const currentGame = currentCache.games[gameId];
+
+  if (
+    currentGame &&
+    factionImageMapsEqual(currentGame.factionImages, normalizedFactionImages)
+  ) {
+    return;
+  }
+
+  persistCache({
+    version: CACHE_VERSION,
+    games: {
+      ...currentCache.games,
+      [gameId]: {
+        factionImages: normalizedFactionImages,
+        updatedAt: Date.now(),
+      },
+    },
+  });
+}


### PR DESCRIPTION
Faction images for background game tabs are now cached in `localStorage` to ensure they display consistently across all open tabs. This avoids blank or default images for inactive tabs. Only image meta data is cached so the cache to be relatively small. The cache is automatically pruned when tabs are closed or entries exceed their maximum age.

Currently, when using non-standard faction images, all inactive game tabs fall back to the default image, some of which are missing or broken images.
<img width="589" height="52" alt="image" src="https://github.com/user-attachments/assets/b8669a8c-4aeb-4148-83f9-45dbc3a966f2" />
<img width="589" height="52" alt="image" src="https://github.com/user-attachments/assets/b96ae250-a258-467f-81d0-9f836638cfc4" />
<img width="589" height="52" alt="image" src="https://github.com/user-attachments/assets/1f34a2ac-b006-43e7-b9fe-5f9a84d39e03" />

This feature will cache user's faction image meta data for each game when that game is selected, and then used the cached data to determine the appropriate images to show.
<img width="589" height="52" alt="image" src="https://github.com/user-attachments/assets/4cf3f77d-dd57-4a5f-9e92-ea9465ab62a1" />

(I wrote up more about this feature, but I was logged in with the wrong GitHub account and the description failed to save when I tried to create the PR and I can't bring myself to be that verbose again.)